### PR TITLE
fix: registers3method to prevent method error

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -113,6 +113,7 @@ gt_default_options <- list(
 
   register_s3_method("knitr", "knit_print", "gt_tbl")
   register_s3_method("htmltools", "as.tags", "gt_tbl")
+  registerS3method("lscape", "knit_asis", lscape.knit_asis)
 
   op <- options()
   toset <- !(names(gt_default_options) %in% names(op))


### PR DESCRIPTION
Error in UseMethod("lscape") :
  no applicable method for 'lscape' applied to an object of class "knit_asis"