### PR TITLE
preserve column names after extract.data.frame #33

### DIFF
--- a/R/utils_render_latex_math.R
+++ b/R/utils_render_latex_math.R
@@ -94,9 +94,11 @@ extract.list <- function(x, y){
 
 extract.data.frame <- function(x, y){
   dfbase <- purrr::map(x, extract, y)
-  as.data.frame(dfbase,
-                row.names = rownames(x),
-                stringsAsFactors = FALSE)
+  ans <- as.data.frame(dfbase,
+                       row.names = rownames(x),
+                       stringsAsFactors = FALSE)
+  colnames(ans) <- names(dfbase)
+  ans
 }
 
 #' @noRd


### PR DESCRIPTION
Simple fix for issue #33 where column names are simplified by `as.data.frame`.

Proposed test here; I wasn't sure what file to put this in, so including the test there. 

Also opening this against master, but I realize it needs to go through dev branch cycle first (not sure what is leading dev branch).  

Need this fix or another fix implemented asap; pmtables development is stopped until this can get fixed. 



```r
test_that("odd column names", {
  df <- data.frame(a = 1)
  names(df) <- "special-name"
  ans <- as_latex(gt(df))
  expect_is(ans, "knit_asis")
  expect_true(grepl("special-name", as.character(ans)))
})
```