### PR TITLE
[do not merge] use new CI images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,3 +62,34 @@ volumes:
 - name: docker.sock
   host:
     path: /var/run/docker.sock
+
+---
+
+kind: pipeline
+type: docker
+name: mrggt-mpn-dev
+
+steps:
+- name: Pull mpn container from ECR
+  image: omerxx/drone-ecr-auth
+  volumes:
+  - name: docker.sock
+    path: /var/run/docker.sock
+  commands:
+  - $(aws ecr get-login --no-include-email --region us-east-1)
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:v1.3
+
+- name: build
+  image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-dev:v1.3"
+  pull: never
+  environment:
+    R_LIBS_USER: "/opt/rpkgs/3.6"
+  commands:
+  - /opt/R/3.6.3/bin/R -e "devtools::install_deps(upgrade = 'never')"
+  - /opt/R/3.6.3/bin/R -e "devtools::test()"
+  - /opt/R/3.6.3/bin/R -e "devtools::check()"
+
+volumes:
+- name: docker.sock
+  host:
+    path: /var/run/docker.sock


### PR DESCRIPTION
This PR will point Drone at the new CI images. v1.3 is used for initial testing.

**This PR should not be merged until the new set of CI images is built.**

FYI @evol262 @bkyoung @dpastoor